### PR TITLE
feat: split mod descriptor into runtime and data components

### DIFF
--- a/assets/definitions/mod_descriptor_schema.json
+++ b/assets/definitions/mod_descriptor_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ModDescriptorAsset",
-  "description": "A descriptor for a mod really. Maybe rename to ModDescriptor.",
+  "title": "ModDescriptor",
+  "description": "Describes the contents of a mod",
   "type": "object",
   "properties": {
     "attachKind": {

--- a/assets/mods/main/spells/fireball.lua
+++ b/assets/mods/main/spells/fireball.lua
@@ -19,6 +19,7 @@ function on_spell_cast(entity)
 end
 
 function on_spell_expired(entity)
+    log_warn("despawning expired:" .. tostring(entity))
     world.despawn(entity)
 end
 
@@ -29,6 +30,7 @@ function on_spell_hit_character(entity, other_entity)
         health.current = health.current - main_fireball_state.damage_per_hit
     end
     world.play_sound_effect(main_fireball_state.sfx_fireball)
+    log_warn("despawning on_hit:" .. tostring(entity))
     world.despawn(entity)
 end
 
@@ -36,5 +38,6 @@ end
 function on_spell_hit_terrain(entity, other_entity)
 
     world.play_sound_effect(main_fireball_state.sfx_fireball)
+    log_warn("despawning on_hit_terrain:" .. tostring(entity))
     world.despawn(entity)
 end

--- a/assets/mods/player/player.lua
+++ b/assets/mods/player/player.lua
@@ -29,14 +29,12 @@ function on_script_loaded()
 
         animation_last_sound_time = 0,
         fire_last_time = 0,
-        animation = "Idle",
+        animation = nil,
         animation_flip_x = false,
         spritesheet = world.load_asset_from_mod("Player", "sprites/wizard.ase"),
         sfx_crunch = world.load_asset_from_mod("Player", "audio/crunch.wav"),
         sfx_step = world.load_asset_from_mod("Player", "audio/step.wav"),
     }
-
-    entity:set_aseprite_animation(state.spritesheet, state.animation)
 end
 
 function on_script_unloaded()
@@ -56,6 +54,10 @@ function on_update(dt, elapsed_seconds)
     local new_mana = math.min(state.mana_component.current + (MANA_RECOVERY_PER_SECOND * dt), state.mana_component.maximum)
     state.mana_component.current = new_mana
 
+    -- TODO on_game_started or something
+    if state.animation == nil then
+        entity:set_aseprite_animation(state.spritesheet, "Idle")
+    end
 end
 
 function on_player_input(inputs, elapsed_seconds)

--- a/src/console/list_mods.rs
+++ b/src/console/list_mods.rs
@@ -2,7 +2,8 @@ use bevy::{asset::Assets, ecs::system::Res};
 use bevy_console::{ConsoleCommand, clap};
 
 use crate::mods::{
-    mod_descriptor_loaded_assets::ModDescriptorLoadedAssets, mod_descriptor_asset::ModDescriptorAsset,
+    mod_descriptor_asset::ModDescriptorAsset,
+    mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
 };
 
 #[derive(clap::Parser, ConsoleCommand)]
@@ -18,7 +19,10 @@ pub fn list_mods_cmd(
         for descriptor in &descriptors.descriptors {
             match descriptor_assets.get(descriptor) {
                 Some(asset) => {
-                    log.reply(format!("\t - {}, {}", asset.name, asset.description));
+                    log.reply(format!(
+                        "\t - {}, {}",
+                        asset.descriptor.name, asset.descriptor.description
+                    ));
                 }
                 None => {
                     log.reply("\t - Unloaded Mod");

--- a/src/mods/assets.rs
+++ b/src/mods/assets.rs
@@ -1,5 +1,6 @@
 use crate::mods::{
-    mod_descriptor_loaded_assets::ModDescriptorLoadedAssets, mod_descriptor_asset::ModDescriptorAsset,
+    mod_descriptor_asset::ModDescriptorAsset,
+    mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
 };
 use bevy::{
     asset::{
@@ -97,14 +98,6 @@ pub fn load_untyped_asset_for_script_descriptor(
 
             info!("Loading asset for mod: {mod_name}, from: '{mod_relative_asset_path}'");
 
-            if let Some(cached) = descriptor
-                .assets
-                .iter()
-                .find(|h| h.path() == Some(&mod_relative_asset_path))
-            {
-                return Ok(Some(cached.clone()));
-            }
-            // TODO: cache
             Ok(Some(asset_server.load_untyped(mod_relative_asset_path)))
         }
         _ => Ok(None),

--- a/src/mods/mod_descriptor_asset.rs
+++ b/src/mods/mod_descriptor_asset.rs
@@ -18,20 +18,22 @@ use crate::{
     spells::spell::SpellComponentDescriptor,
 };
 
-/// A descriptor for a mod really. Maybe rename to ModDescriptor.
-#[derive(Clone, Serialize, Deserialize, Asset, TypePath, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[derive(Asset, TypePath)]
 pub struct ModDescriptorAsset {
+    pub descriptor: ModDescriptor,
+    pub script: Handle<ScriptAsset>,
+}
+
+/// Describes the contents of a mod
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModDescriptor {
     pub name: String,
     pub kind: ScriptKind,
     pub description: String,
     pub version: String,
     pub attach_kind: AttachKind,
     pub dependant_on_lua_scripts: Vec<String>,
-    #[serde(skip_deserializing, skip_serializing, default)]
-    pub script: Handle<ScriptAsset>,
-    #[serde(skip_deserializing, skip_serializing, default)]
-    pub assets: Vec<Handle<LoadedUntypedAsset>>,
     pub spell_components: Vec<Arc<SpellComponentDescriptor>>,
 }
 

--- a/src/mods/mod_descriptor_asset_loader.rs
+++ b/src/mods/mod_descriptor_asset_loader.rs
@@ -1,6 +1,6 @@
 use crate::{
     mods::{
-        mod_descriptor_asset::ModDescriptorAsset,
+        mod_descriptor_asset::{ModDescriptor, ModDescriptorAsset},
         systems::{asset_root_path, recurse_dirs},
     },
     spells::spell,
@@ -32,31 +32,15 @@ impl AssetLoader for ModDescriptorAssetLoader {
 
         reader.read_to_end(&mut buf).await?;
 
-        let mut asset: ModDescriptorAsset =
+        let descriptor: ModDescriptor =
             serde_json::de::from_slice(&buf).map_err(BevyError::from)?;
 
         let asset_path = load_context.path().path();
         let script_path = asset_path.with_extension("").with_extension("lua");
-        let script_assets_path = asset_path.parent().unwrap().join("assets");
-        let absolute_script_assets_path = asset_root_path().join(script_assets_path);
 
-        if absolute_script_assets_path.is_dir() {
-            recurse_dirs(&absolute_script_assets_path, None, &mut |f| {
-                let path = f.to_owned();
-                asset
-                    .assets
-                    .push(load_context.loader().with_unknown_type().load(
-                        AssetPath::from_path_buf(
-                            path.strip_prefix(asset_root_path()).unwrap().to_owned(),
-                        ),
-                    ));
-            })
-            .unwrap();
-        }
+        let script = load_context.load(script_path);
 
-        asset.script = load_context.load(script_path);
-
-        Ok(asset)
+        Ok(ModDescriptorAsset { descriptor, script })
     }
 
     fn extensions(&self) -> &[&str] {

--- a/src/mods/mod_descriptor_loaded_assets.rs
+++ b/src/mods/mod_descriptor_loaded_assets.rs
@@ -33,7 +33,7 @@ impl ModDescriptorLoadedAssets {
         self.descriptors.iter().find_map(|handle| {
             assets
                 .get(handle)
-                .filter(|descriptr| descriptr.name == name)
+                .filter(|descriptor| descriptor.descriptor.name == name)
                 .map(|descriptor| (descriptor, handle.clone()))
         })
     }
@@ -50,9 +50,10 @@ impl ModDescriptorLoadedAssets {
             .find_map(|handle| {
                 assets
                     .get(handle)
-                    .filter(|descriptor| descriptor.name == name)
+                    .filter(|descriptor| descriptor.descriptor.name == name)
                     .and_then(|descriptor| {
                         descriptor
+                            .descriptor
                             .spell_components
                             .iter()
                             .find(|d| d.friendly_name == spell_component)

--- a/src/mods/systems.rs
+++ b/src/mods/systems.rs
@@ -36,8 +36,8 @@ use crate::{
     character::controllable_character::Player,
     input::PlayerInput,
     mods::{
+        mod_descriptor_asset::{AttachKind, ModDescriptor, ModDescriptorAsset, ScriptKind},
         mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
-        mod_descriptor_asset::{AttachKind, ModDescriptorAsset, ScriptKind},
     },
     state::GameState,
 };
@@ -60,10 +60,10 @@ pub fn activate_core_scripts(
         info!("Initializing core scripts");
         for descriptor in &loaded_script_descriptors.descriptors {
             if let Some(descriptor_asset) = script_descriptor_assets.get(descriptor)
-                && descriptor_asset.kind == ScriptKind::Core
+                && descriptor_asset.descriptor.kind == ScriptKind::Core
             {
                 let handle = descriptor_asset.script.clone();
-                match descriptor_asset.attach_kind {
+                match descriptor_asset.descriptor.attach_kind {
                     AttachKind::Static => {
                         commands.queue(AttachScript::<LuaScriptingPlugin>::new(
                             bevy_mod_scripting::script::ScriptAttachment::StaticScript(
@@ -92,7 +92,7 @@ pub fn activate_core_scripts(
 }
 
 pub fn sync_dev_schema() {
-    let schema = serde_json::to_string_pretty(&schema_for!(ModDescriptorAsset))
+    let schema = serde_json::to_string_pretty(&schema_for!(ModDescriptor))
         .expect("Failed to serialize mod schema");
     let path = asset_root_path()
         .join("definitions")
@@ -147,7 +147,7 @@ pub fn load_external_dependencies_in_mods(
     let mut static_scripts_to_attach: HashSet<Handle<ScriptAsset>> = Default::default();
 
     for (asset_id, asset) in descriptors.iter() {
-        for (idx, spell_component) in asset.spell_components.iter().enumerate() {
+        for (idx, spell_component) in asset.descriptor.spell_components.iter().enumerate() {
             let resolution = match spell_component
                 .script_controller_path
                 .asset_path(&loaded_script_descriptors, &descriptors)
@@ -162,7 +162,7 @@ pub fn load_external_dependencies_in_mods(
                 Err(err) => {
                     log::error!(
                         "Failed to resolve script dependency in mod: '{}', on spell_component_controller: '{}': {err}",
-                        asset.name,
+                        asset.descriptor.name,
                         spell_component.script_controller_path
                     );
                     continue;
@@ -181,9 +181,9 @@ pub fn load_external_dependencies_in_mods(
         // could do a mutex or some shit, but this should really only be read only after loading
         // I think reloading might be weird though because arc will get re-created, so remaining handles will point to old spell component
         // maybe that's good
-        let mut cloned = (*asset.spell_components[spell_component_idx]).clone();
+        let mut cloned = (*asset.descriptor.spell_components[spell_component_idx]).clone();
         cloned.script_controller_handle = Some(resolved_script);
-        asset.spell_components[spell_component_idx] = Arc::new(cloned);
+        asset.descriptor.spell_components[spell_component_idx] = Arc::new(cloned);
     }
 
     for script in static_scripts_to_attach.drain() {

--- a/src/spells/executor.rs
+++ b/src/spells/executor.rs
@@ -386,6 +386,8 @@ pub fn progress_spell_executions(
                 }
             };
 
+            trace!("Executing spell event: {:?}", event.payload);
+
             if plan.terminate_spell_after_execution {
                 mark_terminal_state(execution);
             }
@@ -400,25 +402,27 @@ pub fn progress_spell_executions(
 
             // we have to do this here just before the callback
             // because the callback itself may despawn the entity, meaning we won't have access to the transform
-            let cast_location =
-                if let Some(move_to_node) = plan.progress_to_next_spell_after_execution {
-                    let (pos, vel) = match query_state.get(world).get(
-                        if execution.last_cast_entity != Entity::PLACEHOLDER {
+            let cast_location = if plan.progress_to_next_spell_after_execution.is_some() {
+                let (pos, vel) = match query_state.get(world).get(
+                    if execution.last_cast_entity != Entity::PLACEHOLDER {
+                        execution.last_cast_entity
+                    } else {
+                        entity
+                    },
+                ) {
+                    Ok((t, v)) => (t.translation.truncate(), v.linvel),
+                    Err(e) => {
+                        error!(
+                            "Error querying transform in spell cast, last_cast_entity: {:?} : {e}",
                             execution.last_cast_entity
-                        } else {
-                            entity
-                        },
-                    ) {
-                        Ok((t, v)) => (t.translation.truncate(), v.linvel),
-                        Err(e) => {
-                            error!("Error querying transform in spell cast: {e}");
-                            (Default::default(), Default::default())
-                        }
-                    };
-                    Some((pos, vel))
-                } else {
-                    None
+                        );
+                        (Default::default(), Default::default())
+                    }
                 };
+                Some((pos, vel))
+            } else {
+                None
+            };
 
             if let Err(err) = execute_spell_callback(
                 world,
@@ -473,6 +477,8 @@ pub fn plan_execution_for_event(
     };
     let spell_to_execute = current_node.descriptor.clone();
 
+    // TODO: this currently means ANY spell currently spawned can affect the transition
+    // might not be what we want
     let progress_to_next_spell_after_execution = current_node
         .transitions
         .iter()


### PR DESCRIPTION
Makes it a bit easier to reason about, 
TODO: same for spell components
Should we extract them into separate asset entirely? We already keep an Arc handle, which might be more ergonomic with an asset handle