### PR TITLE
feat: extract `SpellComponentAsset` as a separate top level asset

### DIFF
--- a/assets/definitions/mod_descriptor_schema.json
+++ b/assets/definitions/mod_descriptor_schema.json
@@ -49,22 +49,6 @@
         "Static"
       ]
     },
-    "ModPathBuf": {
-      "description": "A [`PathBuf`] but pointing to a specific mod",
-      "type": "object",
-      "properties": {
-        "mod_name": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "mod_name",
-        "path"
-      ]
-    },
     "ScriptKind": {
       "type": "string",
       "enum": [
@@ -116,24 +100,13 @@
           "type": "number",
           "format": "float"
         },
-        "friendly_name": {
-          "description": "The name to show in the UI",
-          "type": "string"
-        },
         "handler_label": {
           "description": "The postfix to give to every handler for this spell. For example if this name is 'my_spell' then the handler for casting the spell\nwould have to be called \"on_cast_my_spell\", and similar for all the other spell callbacks.",
           "type": "string"
         },
-        "icon_sprite_path": {
-          "description": "the path to an icon within the mod that can be shown in the UI, if not provided a placeholder will be used",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ModPathBuf"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "identifier": {
+          "description": "A unique (within the mod) spell name. Typically in snake case.",
+          "type": "string"
         },
         "lifetime_milliseconds": {
           "description": "The time after which this component is killed, and its death effect triggered",
@@ -144,16 +117,11 @@
           "description": "The amount of mana drained every time this component is triggered.\nIf mana is not enough for the next component, firing is blocked.",
           "type": "number",
           "format": "float"
-        },
-        "script_controller_path": {
-          "description": "The controller script for this component.\nAll callbacks and triggers get sent to it while the component is alive",
-          "$ref": "#/$defs/ModPathBuf"
         }
       },
       "required": [
-        "friendly_name",
+        "identifier",
         "handler_label",
-        "script_controller_path",
         "mana_drain_per_shot",
         "delay_milliseconds",
         "lifetime_milliseconds",

--- a/assets/mods/main/main.mod.json
+++ b/assets/mods/main/main.mod.json
@@ -8,7 +8,7 @@
     "attachKind": "Static",
     "spellComponents": [
         {
-            "friendly_name": "fireball",
+            "identifier": "fireball",
             "handler_label": "main_fireball",
             "script_controller_path": {
                 "mod_name": "Main",

--- a/src/mods/mod.rs
+++ b/src/mods/mod.rs
@@ -28,9 +28,8 @@ use crate::{
         mod_descriptor_asset_loader::ModDescriptorAssetLoader,
         mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
         systems::{
-            OnPlayerInput, OnUpdate, activate_core_scripts, dispaptch_on_update,
-            dispatch_on_player_input, init_load_of_all_script_mods,
-            load_external_dependencies_in_mods,
+            OnPlayerInput, OnUpdate, activate_core_scripts, activate_spell_component_scripts,
+            dispaptch_on_update, dispatch_on_player_input, init_load_of_all_script_mods,
         },
     },
     state::GameState,
@@ -115,9 +114,9 @@ impl Plugin for ScriptLoaderPlugin {
                 (
                     // TODO: use a one time schedule for initialization rather than doing game state checks every update
                     (activate_core_scripts).run_if(in_state(GameState::CoreScriptsLoading)),
-                    (load_external_dependencies_in_mods)
+                    (activate_spell_component_scripts)
                         .chain()
-                        .run_if(in_state(GameState::ModDependencyResolution)),
+                        .run_if(in_state(GameState::SpellComponentLoading)),
                     (
                         dispaptch_on_update.in_set(GameSystemSets::UpdateDispatch),
                         dispatch_on_player_input.in_set(GameSystemSets::PlayerInputDispatch),

--- a/src/mods/mod_descriptor_asset.rs
+++ b/src/mods/mod_descriptor_asset.rs
@@ -7,6 +7,7 @@ use std::{
 
 use bevy::{
     asset::{Asset, AssetPath, Assets, Handle, LoadedUntypedAsset},
+    platform::collections::HashMap,
     reflect::{Reflect, TypePath},
 };
 use bevy_mod_scripting::asset::ScriptAsset;
@@ -15,13 +16,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     mods::mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
-    spells::spell::SpellComponentDescriptor,
+    spells::spell_component_asset::{SpellComponentAsset, SpellComponentDescriptor},
 };
 
 #[derive(Asset, TypePath)]
 pub struct ModDescriptorAsset {
     pub descriptor: ModDescriptor,
     pub script: Handle<ScriptAsset>,
+    pub spell_component_asset_handles: HashMap<String, Handle<SpellComponentAsset>>,
 }
 
 /// Describes the contents of a mod
@@ -34,7 +36,7 @@ pub struct ModDescriptor {
     pub version: String,
     pub attach_kind: AttachKind,
     pub dependant_on_lua_scripts: Vec<String>,
-    pub spell_components: Vec<Arc<SpellComponentDescriptor>>,
+    pub spell_components: Vec<SpellComponentDescriptor>,
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]

--- a/src/mods/mod_descriptor_asset_loader.rs
+++ b/src/mods/mod_descriptor_asset_loader.rs
@@ -3,11 +3,13 @@ use crate::{
         mod_descriptor_asset::{ModDescriptor, ModDescriptorAsset},
         systems::{asset_root_path, recurse_dirs},
     },
-    spells::spell,
+    spells::{spell, spell_component_asset::SpellComponentAsset},
 };
 use bevy::{
     asset::{AssetLoader, AssetPath},
     ecs::error::BevyError,
+    log::error,
+    platform::collections::HashMap,
     reflect::TypePath,
 };
 
@@ -40,7 +42,53 @@ impl AssetLoader for ModDescriptorAssetLoader {
 
         let script = load_context.load(script_path);
 
-        Ok(ModDescriptorAsset { descriptor, script })
+        let mut spell_component_asset_handles =
+            HashMap::with_capacity(descriptor.spell_components.len());
+
+        let spell_directory = load_context
+            .path()
+            .parent()
+            .expect("bad path")
+            .resolve("spells")
+            .expect("invalid parse");
+        for spell_component_descriptor in &descriptor.spell_components {
+            let script_path = match spell_directory
+                .resolve(&format!("{}.lua", spell_component_descriptor.identifier))
+            {
+                Ok(path) => path,
+                Err(err) => {
+                    error!(
+                        "Invalid script component identifier, could not build path. Mod: {}, component identifier: {}. {err}",
+                        descriptor.name, spell_component_descriptor.identifier
+                    );
+                    continue;
+                }
+            };
+            let spell_component_asset = load_context
+                .labeled_asset_scope::<SpellComponentAsset, ()>(
+                    format!("spell_component:{}", spell_component_descriptor.identifier),
+                    |a| {
+                        let script = a.load(script_path);
+
+                        Ok(SpellComponentAsset {
+                            descriptor: spell_component_descriptor.clone(),
+                            script,
+                        })
+                    },
+                )
+                .expect("infallible");
+
+            spell_component_asset_handles.insert(
+                spell_component_descriptor.identifier.to_owned(),
+                spell_component_asset,
+            );
+        }
+
+        Ok(ModDescriptorAsset {
+            descriptor,
+            script,
+            spell_component_asset_handles,
+        })
     }
 
     fn extensions(&self) -> &[&str] {

--- a/src/mods/mod_descriptor_loaded_assets.rs
+++ b/src/mods/mod_descriptor_loaded_assets.rs
@@ -10,7 +10,7 @@ use bevy::{
 
 use crate::{
     mods::mod_descriptor_asset::ModDescriptorAsset,
-    spells::spell::{SpellComponentDescriptor, SpellComponentDescriptorHandle},
+    spells::spell_component_asset::SpellComponentAsset,
 };
 
 /// Exists to keep asset handles alive
@@ -44,7 +44,7 @@ impl ModDescriptorLoadedAssets {
         name: &str,
         spell_component: &str,
         assets: &'a Assets<ModDescriptorAsset>,
-    ) -> Option<SpellComponentDescriptorHandle> {
+    ) -> Option<Handle<SpellComponentAsset>> {
         self.descriptors
             .iter()
             .find_map(|handle| {
@@ -53,13 +53,10 @@ impl ModDescriptorLoadedAssets {
                     .filter(|descriptor| descriptor.descriptor.name == name)
                     .and_then(|descriptor| {
                         descriptor
-                            .descriptor
-                            .spell_components
-                            .iter()
-                            .find(|d| d.friendly_name == spell_component)
+                            .spell_component_asset_handles
+                            .get(spell_component)
                     })
             })
             .cloned()
-            .map(SpellComponentDescriptorHandle)
     }
 }

--- a/src/mods/systems.rs
+++ b/src/mods/systems.rs
@@ -13,7 +13,7 @@ use bevy::{
         keyboard::{Key, KeyCode},
         mouse::MouseButton,
     },
-    log::{self, info, trace},
+    log::{self, error, info, trace},
     platform::collections::{HashMap, HashSet},
     state::state::NextState,
     time::{Real, Time},
@@ -39,6 +39,7 @@ use crate::{
         mod_descriptor_asset::{AttachKind, ModDescriptor, ModDescriptorAsset, ScriptKind},
         mod_descriptor_loaded_assets::ModDescriptorLoadedAssets,
     },
+    spells::spell_component_asset::SpellComponentAsset,
     state::GameState,
 };
 
@@ -87,7 +88,7 @@ pub fn activate_core_scripts(
 
     if pipeline_state.processing_batch_completed() && loaded > 1 {
         info!("Loaded {total} mods");
-        next_state.set(GameState::ModDependencyResolution)
+        next_state.set(GameState::SpellComponentLoading)
     }
 }
 
@@ -132,64 +133,31 @@ pub fn init_load_of_all_script_mods(
     .expect("failed to read script assets");
 }
 
-/// Completes loading of mods, by resolving any pointers to external mods as handles etc.
-///
-/// Ideally we should also re-do this if new assets are added, but that's rare enough it's probably fine, downstream changes to the script will re-load the script itself.
-pub fn load_external_dependencies_in_mods(
+pub fn activate_spell_component_scripts(
     mut commands: Commands,
-    loaded_script_descriptors: Res<ModDescriptorLoadedAssets>,
-    mut descriptors: ResMut<Assets<ModDescriptorAsset>>,
+    loaded_mod_descriptors: Res<ModDescriptorLoadedAssets>,
+    mod_assets: Res<Assets<ModDescriptorAsset>>,
+    spell_component_assets: Res<Assets<SpellComponentAsset>>,
     mut next_state: ResMut<NextState<GameState>>,
-    asset_server: Res<AssetServer>,
 ) {
-    let mut script_resolutions: HashMap<(AssetId<ModDescriptorAsset>, usize), Handle<ScriptAsset>> =
-        Default::default();
-    let mut static_scripts_to_attach: HashSet<Handle<ScriptAsset>> = Default::default();
-
-    for (asset_id, asset) in descriptors.iter() {
-        for (idx, spell_component) in asset.descriptor.spell_components.iter().enumerate() {
-            let resolution = match spell_component
-                .script_controller_path
-                .asset_path(&loaded_script_descriptors, &descriptors)
-            {
-                Ok(resolved) => {
-                    trace!(
-                        "Resolving script controller path: {}, with: {}",
-                        spell_component.script_controller_path, resolved
+    // we could just iterate over the assets resource directly, but this way we check everything is complete I guess
+    for mod_descriptor in &loaded_mod_descriptors.descriptors {
+        if let Some(mod_descriptor_asset) = mod_assets.get(mod_descriptor) {
+            for (_, spell_descriptor) in &mod_descriptor_asset.spell_component_asset_handles {
+                if let Some(spell_descriptor_asset) = spell_component_assets.get(spell_descriptor) {
+                    commands.queue(AttachScript::<LuaScriptingPlugin>::new(
+                        ScriptAttachment::StaticScript(spell_descriptor_asset.script.clone()),
+                    ));
+                } else {
+                    error!(
+                        "Missing spell component descriptor asset: {:?}",
+                        spell_descriptor
                     );
-                    asset_server.load(resolved)
                 }
-                Err(err) => {
-                    log::error!(
-                        "Failed to resolve script dependency in mod: '{}', on spell_component_controller: '{}': {err}",
-                        asset.descriptor.name,
-                        spell_component.script_controller_path
-                    );
-                    continue;
-                }
-            };
-            script_resolutions.insert((asset_id, idx), resolution.clone());
-            static_scripts_to_attach.insert(resolution);
+            }
+        } else {
+            error!("Missing mod descriptor asset: {:?}", mod_descriptor);
         }
-    }
-
-    // apply resolutions
-    for ((asset_id, spell_component_idx), resolved_script) in script_resolutions {
-        let asset = descriptors
-            .get_mut_untracked(asset_id)
-            .expect("invariant broken: previously resolved asset missing");
-        // could do a mutex or some shit, but this should really only be read only after loading
-        // I think reloading might be weird though because arc will get re-created, so remaining handles will point to old spell component
-        // maybe that's good
-        let mut cloned = (*asset.descriptor.spell_components[spell_component_idx]).clone();
-        cloned.script_controller_handle = Some(resolved_script);
-        asset.descriptor.spell_components[spell_component_idx] = Arc::new(cloned);
-    }
-
-    for script in static_scripts_to_attach.drain() {
-        commands.queue(AttachScript::<LuaScriptingPlugin>::new(
-            ScriptAttachment::StaticScript(script),
-        ));
     }
 
     next_state.set(GameState::Running);

--- a/src/spells/dotgraph.rs
+++ b/src/spells/dotgraph.rs
@@ -1,15 +1,15 @@
 
 use crate::{
     mods::{
-        mod_descriptor_loaded_assets::ModDescriptorLoadedAssets, mod_descriptor_asset::ModDescriptorAsset,
+        mod_descriptor_asset::ModDescriptorAsset, mod_descriptor_loaded_assets::ModDescriptorLoadedAssets
     },
     spells::{
-        executor::{Spell},
-        spell::{SpellComponentDescriptor, SpellComponentDescriptorHandle},
+        executor::Spell,
+        spell_component_asset::SpellComponentAsset,
     },
 };
 use bevy::
-    asset::Assets
+    asset::{Assets, Handle}
 ;
 use petgraph::{Graph, dot::dot_parser::ParseFromDot};
 use petgraph::
@@ -19,7 +19,7 @@ use petgraph::
 // TODO: don't clone descriptors everywhere, store handles
 #[derive(Clone, Debug)]
 pub struct SpellGraphNode {
-    pub descriptor: SpellComponentDescriptorHandle,
+    pub descriptor: Handle<SpellComponentAsset>,
 }
 
 #[derive(Clone, Debug)]
@@ -47,7 +47,7 @@ pub fn dot_graph_to_spell_graph(
             start_node = Some(i);
         }
 
-        let res: Result<SpellComponentDescriptorHandle, String> = (|| {
+        let res: Result<Handle<SpellComponentAsset>, String> = (|| {
 
             let label = node.attr.elems.iter()
                 .find_map(|(key,val)| (*key == "label").then_some(*val))
@@ -68,7 +68,7 @@ pub fn dot_graph_to_spell_graph(
             Err(e) => {
                 last_err = Err(e);
                 return SpellGraphNode{
-                    descriptor: SpellComponentDescriptorHandle(SpellComponentDescriptor::default().into())
+                    descriptor: Handle::default()
                 }
             },
         };

--- a/src/spells/executor.rs
+++ b/src/spells/executor.rs
@@ -1,6 +1,7 @@
 use std::{collections::VecDeque, fmt, ops::Index, sync::atomic::AtomicUsize};
 
 use bevy::{
+    asset::{AssetPath, Assets, Handle},
     ecs::{
         entity::Entity,
         error::trace,
@@ -35,7 +36,8 @@ use petgraph::{
 
 use crate::spells::{
     dotgraph::{SpellGraphNode, SpellGraphTransition},
-    spell::{LiveSpell, SpellComponentDescriptor, SpellComponentDescriptorHandle},
+    spell::LiveSpell,
+    spell_component_asset::SpellComponentAsset,
 };
 
 type NodeId = usize;
@@ -50,7 +52,7 @@ pub struct Spell {
 
 #[derive(Reflect, Debug)]
 pub struct SpellComponent {
-    pub descriptor: SpellComponentDescriptorHandle,
+    pub descriptor: Handle<SpellComponentAsset>,
     pub transitions: Vec<(SpellTransitionTrigger, NodeId)>,
 }
 
@@ -100,7 +102,7 @@ impl Spell {
         let mut idx = 0;
         while let Some(next) = dfs.next(&graph) {
             dfs_index_of[next.index()] = idx;
-            idx = idx + 1;
+            idx += 1;
         }
 
         let mut nodes = Vec::with_capacity(dfs_index_of.len());
@@ -109,7 +111,7 @@ impl Spell {
             let transitions = graph
                 .edges_directed(node_idx, petgraph::Direction::Outgoing)
                 .map(|edge| {
-                    let trigger_event = edge.weight().modifier_event.as_ref().map(|s| s.as_str());
+                    let trigger_event = edge.weight().modifier_event.as_deref();
                     let trigger = SpellTransitionTrigger::new(trigger_event);
                     let target = edge.target();
                     let target_dfs_idx = dfs_index_of[target.index()];
@@ -140,7 +142,13 @@ impl Spell {
                         .map(|event| format!("label=\"{}\"", event))
                         .unwrap_or_default()
                 },
-                &|_, (_, node)| format!("label=\"{}\"", node.descriptor.friendly_name),
+                &|_, (_, node)| format!(
+                    "label=\"{}\"",
+                    node.descriptor
+                        .path()
+                        .map(|p| p.to_string())
+                        .unwrap_or_else(|| String::from("missing asset path"))
+                ),
             )
         );
 
@@ -347,7 +355,7 @@ pub fn spell_executions_live(executions: Res<AbilityExecutions>) -> bool {
 // borrow checker friendly encapsulation
 #[derive(Debug)]
 struct StepPlan {
-    spell_to_execute: SpellComponentDescriptorHandle,
+    spell_component_to_execute: Handle<SpellComponentAsset>,
     progress_to_next_spell_after_execution: Option<NodeId>,
     terminate_spell_after_execution: bool,
 }
@@ -364,6 +372,9 @@ pub fn progress_spell_executions(
         .get_resource::<AppReflectAllocator>()
         .cloned()
         .expect("missing allocator");
+
+    let spell_descriptor_assets: Assets<SpellComponentAsset> =
+        world.remove_resource().expect("missing resource");
 
     let mut any_finished = false;
 
@@ -386,6 +397,19 @@ pub fn progress_spell_executions(
                 }
             };
 
+            let spell_descriptor_asset =
+                match spell_descriptor_assets.get(&plan.spell_component_to_execute) {
+                    Some(asset) => asset,
+                    None => {
+                        error!(
+                            "Spell execution failed, missing asset: {:?}",
+                            plan.spell_component_to_execute.path()
+                        );
+                        mark_terminal_state(execution);
+                        continue;
+                    }
+                };
+
             trace!("Executing spell event: {:?}", event.payload);
 
             if plan.terminate_spell_after_execution {
@@ -397,7 +421,8 @@ pub fn progress_spell_executions(
                 &allocator,
                 execution,
                 &event,
-                &plan.spell_to_execute,
+                spell_descriptor_asset,
+                &plan.spell_component_to_execute,
             );
 
             // we have to do this here just before the callback
@@ -428,7 +453,7 @@ pub fn progress_spell_executions(
                 world,
                 &allocator,
                 &event,
-                &plan.spell_to_execute,
+                spell_descriptor_asset,
                 entity_ref,
             ) {
                 error!("Spell execution failed: {err}");
@@ -459,6 +484,7 @@ pub fn progress_spell_executions(
     }
 
     world.insert_resource(executions);
+    world.insert_resource(spell_descriptor_assets);
 }
 
 pub fn plan_execution_for_event(
@@ -485,7 +511,7 @@ pub fn plan_execution_for_event(
         .find_map(|(t, next)| t.satisfied_by(payload).then_some(*next));
 
     Ok(StepPlan {
-        spell_to_execute,
+        spell_component_to_execute: spell_to_execute,
         progress_to_next_spell_after_execution,
         terminate_spell_after_execution: matches!(payload, SpellEventPayload::Expired { .. }),
     })
@@ -495,7 +521,7 @@ fn execute_spell_callback(
     world: &mut World,
     allocator: &AppReflectAllocator,
     event: &SpellEvent,
-    spell: &SpellComponentDescriptor,
+    spell: &SpellComponentAsset,
     entity_ref: ReflectReference,
 ) -> Result<(), ScriptError> {
     let mut allocator = allocator.write();
@@ -503,7 +529,9 @@ fn execute_spell_callback(
     event.payload.add_args(&mut allocator, &mut args);
     drop(allocator);
 
-    let label = event.payload.to_callback_label(&spell.handler_label);
+    let label = event
+        .payload
+        .to_callback_label(&spell.descriptor.handler_label);
 
     run_spell_callback(world, args, spell, label).map(|_| ())
 }
@@ -513,7 +541,8 @@ fn resolve_or_spawn_cast_entity(
     allocator: &AppReflectAllocator,
     execution: &AbilityExecution,
     event: &SpellEvent,
-    spell: &SpellComponentDescriptorHandle,
+    spell: &SpellComponentAsset,
+    handle: &Handle<SpellComponentAsset>,
 ) -> (ReflectReference, Entity) {
     let mut allocator = allocator.write();
     match event.payload.spell_entity() {
@@ -526,7 +555,14 @@ fn resolve_or_spawn_cast_entity(
                 .get_resource::<Time<Virtual>>()
                 .expect("missing time resource");
             let entity = world
-                .spawn(LiveSpell::new(execution.id, pos, vel, time, spell.clone()))
+                .spawn(LiveSpell::new(
+                    execution.id,
+                    pos,
+                    vel,
+                    time,
+                    handle.clone(),
+                    spell,
+                ))
                 .id();
 
             let allocated = ReflectReference::new_allocated(entity, &mut allocator);
@@ -539,15 +575,10 @@ fn resolve_or_spawn_cast_entity(
 fn run_spell_callback(
     world: &mut World,
     args: Vec<ScriptValue>,
-    parent: &SpellComponentDescriptor,
+    parent: &SpellComponentAsset,
     label: CallbackLabel,
 ) -> Result<ScriptValue, ScriptError> {
-    let handle = parent.script_controller_handle.clone().ok_or_else(|| {
-        ScriptError::from(InteropError::string(format!(
-            "could not find script controller: {}",
-            parent.script_controller_path
-        )))
-    })?;
+    let handle = parent.script.clone();
 
     let cmd = RunScriptCallback::<LuaScriptingPlugin>::new(
         ScriptAttachment::StaticScript(handle),
@@ -556,6 +587,6 @@ fn run_spell_callback(
         false,
     )
     .with_send_errors(true)
-    .with_error_context(format!("running spell: {}", parent.friendly_name));
+    .with_error_context(format!("running spell: {}", parent.descriptor.identifier));
     cmd.run(world)
 }

--- a/src/spells/lifecycle.rs
+++ b/src/spells/lifecycle.rs
@@ -14,7 +14,7 @@ use crate::{
     character::controllable_character::{Character, Player},
     spells::{
         executor::{SpellEvent, SpellEventPayload},
-        spell::{ExecutingSpellComponent, SpellComponentDescriptor, WithLifetime},
+        spell::{ExecutingSpellComponent, WithLifetime},
     },
 };
 

--- a/src/spells/mod.rs
+++ b/src/spells/mod.rs
@@ -1,5 +1,6 @@
 use bevy::{
     app::{Plugin, PostUpdate, Update},
+    asset::AssetApp,
     ecs::schedule::IntoScheduleConfigs,
 };
 use bevy_mod_scripting::{lua::LuaScriptingPlugin, prelude::event_handler};
@@ -13,6 +14,7 @@ use crate::{
         },
         lifecycle::{trigger_spell_expirations, trigger_spell_hits},
         mana::Mana,
+        spell_component_asset::SpellComponentAsset,
     },
     system_sets::GameSystemSets,
 };
@@ -23,13 +25,15 @@ pub mod executor;
 pub mod lifecycle;
 pub mod mana;
 pub mod spell;
+pub mod spell_component_asset;
 
 pub struct GameSpellsPlugin;
 
 impl Plugin for GameSpellsPlugin {
     fn build(&self, app: &mut bevy::app::App) {
         app.add_message::<SpellEvent>()
-            .init_resource::<AbilityExecutions>();
+            .init_resource::<AbilityExecutions>()
+            .init_asset::<SpellComponentAsset>();
 
         // rapier runs in update
         // our scripts will have to react accordingly

--- a/src/spells/spell.rs
+++ b/src/spells/spell.rs
@@ -39,69 +39,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    character::controllable_character::Character, mods::mod_descriptor_asset::ModPathBuf,
-    physics::CollisionGroup, spells::executor::AbilityExecutionId,
+    character::controllable_character::Character,
+    mods::mod_descriptor_asset::ModPathBuf,
+    physics::CollisionGroup,
+    spells::{executor::AbilityExecutionId, spell_component_asset::SpellComponentAsset},
 };
-
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, Reflect)]
-pub enum SlotCount {
-    #[default]
-    None,
-    Unlimited,
-    FixedAmount(usize),
-}
-
-/// A reference to a spell component descriptor, used to avoid cloning excessively, and reduce stack size of structs
-#[derive(Reflect, Clone, Deref, DerefMut, Debug)]
-pub struct SpellComponentDescriptorHandle(pub Arc<SpellComponentDescriptor>);
-
-impl From<SpellComponentDescriptor> for SpellComponentDescriptorHandle {
-    fn from(value: SpellComponentDescriptor) -> Self {
-        Self(Arc::new(value))
-    }
-}
-
-/// A descriptor for a
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Reflect)]
-pub struct SpellComponentDescriptor {
-    /// The name to show in the UI
-    pub friendly_name: String,
-    /// The postfix to give to every handler for this spell. For example if this name is 'my_spell' then the handler for casting the spell
-    /// would have to be called "on_cast_my_spell", and similar for all the other spell callbacks.
-    pub handler_label: String,
-    /// the path to an icon within the mod that can be shown in the UI, if not provided a placeholder will be used
-    pub icon_sprite_path: Option<ModPathBuf>,
-    /// The controller script for this component.
-    /// All callbacks and triggers get sent to it while the component is alive
-    pub script_controller_path: ModPathBuf,
-    #[serde(skip_deserializing, skip_serializing, default)]
-    pub script_controller_handle: Option<Handle<ScriptAsset>>,
-    /// The amount of mana drained every time this component is triggered.
-    /// If mana is not enough for the next component, firing is blocked.
-    pub mana_drain_per_shot: f32,
-    /// The delay after which the next component can be triggered following this one.
-    /// If less than the time between frames, will trigger a
-    /// component every frame, but no more frequently than that.
-    pub delay_milliseconds: f32,
-    /// The time after which this component is killed, and its death effect triggered
-    pub lifetime_milliseconds: f32,
-    /// Components can be slotted with children components, for example
-    /// a grouping component might trigger effects within its children components every frame
-    #[serde(default)]
-    pub children_slots: SlotCount,
-    /// If a component has an area of effect, the engine will provide nearest entities/projectiles to its callbacks
-    pub area_of_effect_meters: f32,
-}
-
-impl std::fmt::Debug for SpellComponentDescriptor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SpellComponentDescriptor")
-            .field("friendly_name", &self.friendly_name)
-            .field("handler_label", &self.handler_label)
-            .field("script_controller_path", &self.script_controller_path)
-            .finish()
-    }
-}
 
 #[derive(Component)]
 pub struct WithLifetime {
@@ -116,7 +58,7 @@ pub struct WithLifetime {
 #[derive(Component, Reflect)]
 #[reflect(Component)]
 pub struct ExecutingSpellComponent {
-    pub descriptor: SpellComponentDescriptorHandle,
+    pub descriptor: Handle<SpellComponentAsset>,
     pub execution_id: AbilityExecutionId,
 }
 
@@ -148,18 +90,19 @@ impl LiveSpell {
         position: Vec2,
         velocity: Vec2,
         time: &Time<Virtual>,
-        descriptor: SpellComponentDescriptorHandle,
+        handle: Handle<SpellComponentAsset>,
+        descriptor: &SpellComponentAsset,
     ) -> Self {
         let diameter = 0.1;
         Self {
-            name: Name::new(descriptor.friendly_name.clone()),
+            name: Name::new(descriptor.descriptor.identifier.clone()),
             lifetime: WithLifetime {
                 start_at: time.elapsed_secs_wrapped_f64(),
                 expired: false,
-                lifetime_seconds: descriptor.lifetime_milliseconds as f64 / 1000.,
+                lifetime_seconds: descriptor.descriptor.lifetime_milliseconds as f64 / 1000.,
             },
             spell_component: ExecutingSpellComponent {
-                descriptor,
+                descriptor: handle,
                 execution_id,
             },
             colider: Collider::ball(diameter / 2.),

--- a/src/spells/spell_component_asset.rs
+++ b/src/spells/spell_component_asset.rs
@@ -1,0 +1,55 @@
+use bevy::{
+    asset::{Asset, Handle},
+    reflect::{Reflect, TypePath},
+};
+use bevy_mod_scripting::asset::ScriptAsset;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Asset, TypePath, Default)]
+pub struct SpellComponentAsset {
+    pub descriptor: SpellComponentDescriptor,
+    pub script: Handle<ScriptAsset>,
+}
+
+/// A descriptor for a
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Reflect)]
+pub struct SpellComponentDescriptor {
+    /// A unique (within the mod) spell name. Typically in snake case.
+    pub identifier: String,
+    /// The postfix to give to every handler for this spell. For example if this name is 'my_spell' then the handler for casting the spell
+    /// would have to be called "on_cast_my_spell", and similar for all the other spell callbacks.
+    pub handler_label: String,
+    /// The amount of mana drained every time this component is triggered.
+    /// If mana is not enough for the next component, firing is blocked.
+    pub mana_drain_per_shot: f32,
+    /// The delay after which the next component can be triggered following this one.
+    /// If less than the time between frames, will trigger a
+    /// component every frame, but no more frequently than that.
+    pub delay_milliseconds: f32,
+    /// The time after which this component is killed, and its death effect triggered
+    pub lifetime_milliseconds: f32,
+    /// Components can be slotted with children components, for example
+    /// a grouping component might trigger effects within its children components every frame
+    #[serde(default)]
+    pub children_slots: SlotCount,
+    /// If a component has an area of effect, the engine will provide nearest entities/projectiles to its callbacks
+    pub area_of_effect_meters: f32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, Reflect)]
+pub enum SlotCount {
+    #[default]
+    None,
+    Unlimited,
+    FixedAmount(usize),
+}
+
+impl std::fmt::Debug for SpellComponentAsset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpellComponentDescriptor")
+            .field("friendly_name", &self.descriptor.identifier)
+            .field("handler_label", &self.descriptor.handler_label)
+            .finish()
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -15,6 +15,6 @@ impl Plugin for ArcaneAssemblyGameStatePlugin {
 pub enum GameState {
     #[default]
     CoreScriptsLoading,
-    ModDependencyResolution,
+    SpellComponentLoading,
     Running,
 }


### PR DESCRIPTION
Still retains the unity of a single mod manifest, but allows us to keep handles to spell component assets directly, much better re-loading semantics, as well as better queryability