### PR TITLE
feat: adds mana and delay calculation to spell executor

### DIFF
--- a/assets/definitions/bindings.d.lua
+++ b/assets/definitions/bindings.d.lua
@@ -44,17 +44,19 @@ function World.get_parent(entity) end
 
 ---@param spell Spell 
 --- the spell to cast
+---@param caster Entity 
 ---@param position Vec2 
 --- the position of the cast
 ---@param velocity Vec2 
 --- the velocity of the cast
 ---@return nil
-function World.cast_spell(spell,position,velocity) end
+function World.cast_spell(spell,caster,position,velocity) end
 
 ---@param center Vec2 
 ---@param radius number 
+---@param groups Group 
 ---@return Entity[]
-function World.circle_collision_query(center,radius) end
+function World.circle_collision_query(center,radius,groups) end
 
 ---@param effect any 
 ---@param parent_entity Entity 
@@ -7598,6 +7600,28 @@ function Instant.saturating_duration_since(_self,earlier) end
 ---@param _self Instant 
 ---@return nil
 function Instant.assert_receiver_is_total_eq(_self) end
+
+
+
+---@class Group : ReflectReference
+---  A bit mask identifying groups for interaction.
+---@field  [1]  integer
+Group = {}
+
+---@return Group
+function Group.ENTITY() end
+
+---@return Group
+function Group.PROJECTILE() end
+
+---@return Group
+function Group.ENTITY_AND_TERRAIN() end
+
+---@return Group
+function Group.TERRAIN() end
+
+---@return Group
+function Group.ALL() end
 
 
 
@@ -25675,6 +25699,7 @@ SlotCount = {}
 ---@field  children_slots ? SlotCount
 ---@field  area_of_effect_meters ? number
 ---@field  disable_collisions ? boolean
+---@field  dont_expire_on_hit ? boolean
 SpellComponentDescriptor = {}
 
 
@@ -31445,13 +31470,6 @@ ContactSkin = {}
 ---@field  coefficient ? number
 ---@field  combine_rule ? CoefficientCombineRule
 Friction = {}
-
-
-
----@class Group : ReflectReference
----  A bit mask identifying groups for interaction.
----@field  [1]  integer
-Group = {}
 
 
 

--- a/assets/definitions/mod_descriptor_schema.json
+++ b/assets/definitions/mod_descriptor_schema.json
@@ -96,12 +96,17 @@
           "default": "None"
         },
         "delay_milliseconds": {
-          "description": "The delay after which the next component can be triggered following this one.\nIf less than the time between frames, will trigger a\ncomponent every frame, but no more frequently than that.",
+          "description": "The delay after which the next component can be triggered following this one.\nIf less than the time between frames, will trigger a\ncomponent every frame, but no more frequently than that.\n\nThe delay only applies after the component is cast, before the next one is executed",
           "type": "number",
-          "format": "float"
+          "format": "double"
         },
         "disable_collisions": {
           "description": "If false will spawn a collider on the spell and send collision events to the spell",
+          "type": "boolean",
+          "default": false
+        },
+        "dont_expire_on_hit": {
+          "description": "If set will prevent the component from being killed when\nit hits an entity or terrain",
           "type": "boolean",
           "default": false
         },

--- a/assets/mods/main/main.mod.json
+++ b/assets/mods/main/main.mod.json
@@ -10,8 +10,8 @@
         {
             "identifier": "fireball",
             "handler_label": "main_fireball",
-            "mana_drain_per_shot": 1,
-            "delay_milliseconds": 100,
+            "mana_drain_per_shot": 5,
+            "delay_milliseconds": 50,
             "lifetime_milliseconds": 1000,
             "area_of_effect_meters": 0,
             "children_slots": "None",
@@ -20,9 +20,9 @@
         {
             "identifier": "explosion",
             "handler_label": "main_explosion",
-            "mana_drain_per_shot": 1,
-            "delay_milliseconds": 100,
-            "lifetime_milliseconds": 1,
+            "mana_drain_per_shot": 10,
+            "delay_milliseconds": 1000,
+            "lifetime_milliseconds": 0,
             "area_of_effect_meters": 0,
             "children_slots": "None",
             "icon_sprite_path": null,

--- a/assets/mods/main/spells/explosion.lua
+++ b/assets/mods/main/spells/explosion.lua
@@ -1,6 +1,7 @@
 main_explosion_state = {
     damage_per_hit = 50,
-    radius = 1
+    radius = 1,
+    explosion_collision_groups = Group.ENTITY()
 }
 
 function make_particle_effect()
@@ -29,15 +30,15 @@ function make_particle_effect()
     color = module:pack4x8snorm(color)
 
     -- speed and shape
-    local speed = module:lit_f32(2)
+    local speed = module:lit_f32(0.5)
     local surface_dimension = ShapeDimension.volume()
-    local size = module:lit_f32(0.05)
+    local size = module:lit_f32(0.1)
     local lifetime = module:lit_f32(0.8)
     local roundness = module:lit_f32(0.4)
 
     -- local gravity = module:lit_vec3(Vec3.new(0.0, -9.8, 0.0))
     local drag = module:rand(ValueType.float())
-    drag = module:mul(drag, module:lit_f32(15))
+    drag = module:mul(drag, module:lit_f32(10))
 
     local axis_up = module:lit_vec3(Vec3.new(0.0, 0.0, 1.0))
 
@@ -57,7 +58,7 @@ function make_particle_effect()
     local effect =
         builder
             :with_capacity(100)
-            :with_spawner_particle_count(20)
+            :with_spawner_particle_count(100)
             :with_spawner_cycle_period(0)
             :with_spawner_cycle_time(0.1)
             :with_spawner_cycle_count(1)
@@ -77,11 +78,6 @@ end
 
 function on_script_loaded()
     register_callback("on_cast_main_explosion", on_spell_cast)
-    -- register_callback("on_hit_character_main_explosion", on_spell_hit_character)
-    -- register_callback("on_hit_terrain_main_explosion", on_spell_hit_terrain)
-    -- register_callback("on_expired_main_explosion", on_spell_expired)
-
-  
     main_explosion_state.particle_effect = make_particle_effect()
 end
 
@@ -91,7 +87,7 @@ function on_spell_cast(entity)
     ---@type Transform
     local transform = world.get_component(entity, types.Transform)
     local position = transform.translation
-    local entities_hit = world.circle_collision_query(position, main_explosion_state.radius)
+    local entities_hit = world.circle_collision_query(position, main_explosion_state.radius, main_explosion_state.explosion_collision_groups)
     world.spawn_particle_effect_one_shot(main_explosion_state.particle_effect, position, 1)
     for i,hit_entity in pairs(entities_hit) do
         ---@type Health?
@@ -101,22 +97,3 @@ function on_spell_cast(entity)
         end
     end
 end
-
--- function on_spell_expired(entity)
--- end
-
--- --- Emits sounds and particles as appropriate
--- ---@param entity Entity
--- function collision_effects(entity)
---     world.play_sound_effect(main_explosion_state.sfx_fireball)
--- end
-
--- function on_spell_hit_character(entity, other_entity)
---     ---@type Health
---     local health = world.get_component(other_entity, main_explosion_state.type_health_component)
---     if health ~= nil then
---         health.current = health.current - main_explosion_state.damage_per_hit
---     end
---     collision_effects(entity)
--- end
-

--- a/assets/mods/player/player.lua
+++ b/assets/mods/player/player.lua
@@ -7,7 +7,6 @@ local input_to_animation_map = {
 }
 local STEP_SFX_PERIOD_SECONDS = 0.3
 local MIN_FIRE_DELAY_SECONDS = 0.16
-local MANA_CONSUMPTION = 10
 local MANA_RECOVERY_PER_SECOND = 33
 local SPELL_TEXT = [[
 digraph {
@@ -91,26 +90,22 @@ function on_player_input(inputs, elapsed_seconds)
     end
 
     if spell_fired and (elapsed_seconds - state.fire_last_time > MIN_FIRE_DELAY_SECONDS) then
-        local new_mana = state.mana_component.current - MANA_CONSUMPTION
-        if new_mana <= 0 then
-            return
-        else
-            state.mana_component.current = new_mana
-            state.fire_last_time = elapsed_seconds
 
-            ---@type MousePositionInWorldCoordinates
-            local mouse_pos = world.get_resource(types.MousePositionInWorldCoordinates)
-            ---@type GlobalTransform
-            local entity_transform =  world.get_component(entity, types.GlobalTransform)
-            local entity_world_pos_2d = entity_transform:translation():truncate()
-            local speed_m = 10
+        state.fire_last_time = elapsed_seconds
 
-            world.cast_spell(
-                state.spell_graph,
-                mouse_pos[1],
-                Vec2.new(mouse_pos[1].x - entity_world_pos_2d.x, 2) * speed_m
-            )
-        end
+        ---@type MousePositionInWorldCoordinates
+        local mouse_pos = world.get_resource(types.MousePositionInWorldCoordinates)
+        ---@type GlobalTransform
+        local entity_transform =  world.get_component(entity, types.GlobalTransform)
+        local entity_world_pos_2d = entity_transform:translation():truncate()
+        local speed_m = 10
+
+        world.cast_spell(
+            state.spell_graph,
+            entity,
+            mouse_pos[1],
+            Vec2.new(mouse_pos[1].x - entity_world_pos_2d.x, 2) * speed_m
+        )
 
 
     end

--- a/src/physics/bindings.rs
+++ b/src/physics/bindings.rs
@@ -15,8 +15,10 @@ use bevy_mod_scripting::{
 use bevy_rapier2d::{
     parry::shape::{Ball, Shape},
     plugin::ReadRapierContext,
-    prelude::{Collider, QueryFilter, ShapeCastOptions},
+    prelude::{Collider, CollisionGroups, Group, QueryFilter, ShapeCastOptions},
 };
+
+use crate::physics::CollisionGroup;
 
 #[derive(Resource)]
 pub struct CollisionQueryCachedState(SystemState<ReadRapierContext<'static, 'static>>);
@@ -24,6 +26,29 @@ pub struct CollisionQueryCachedState(SystemState<ReadRapierContext<'static, 'sta
 impl FromWorld for CollisionQueryCachedState {
     fn from_world(world: &mut World) -> Self {
         Self(SystemState::new(world))
+    }
+}
+
+#[script_bindings(remote, name = "group_functions")]
+impl Group {
+    pub fn PROJECTILE() -> V<Group> {
+        Group::from(CollisionGroup::Projectile).into()
+    }
+    pub fn ENTITY() -> V<Group> {
+        Group::from(CollisionGroup::ControlledEntity).into()
+    }
+    pub fn TERRAIN() -> V<Group> {
+        Group::from(CollisionGroup::Terrain).into()
+    }
+
+    pub fn ALL() -> V<Group> {
+        Group::all().into()
+    }
+
+    pub fn ENTITY_AND_TERRAIN() -> V<Group> {
+        Group::from(CollisionGroup::Terrain)
+            .union(Group::from(CollisionGroup::ControlledEntity))
+            .into()
     }
 }
 
@@ -36,6 +61,7 @@ impl World {
         ctxt: FunctionCallContext,
         center: V<Vec2>,
         radius: f32,
+        groups: V<Group>,
     ) -> Result<Vec<V<Entity>>, InteropError> {
         let world = ctxt.world()?;
 
@@ -48,7 +74,7 @@ impl World {
                     *center,
                     Default::default(),
                     &Ball::new(radius),
-                    QueryFilter::new(),
+                    QueryFilter::new().groups(CollisionGroups::new(groups.0, groups.0)),
                     |entity| {
                         entities.push(entity.into());
                         true

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,11 +1,17 @@
-use bevy::{app::Plugin, ecs::bundle::Bundle, math::Vec2};
+use bevy::{app::Plugin, ecs::bundle::Bundle, math::Vec2, reflect::Reflect};
+use bevy_mod_scripting::{
+    ArgMeta, GetTypeDependencies, TypedThrough,
+    bindings::{FromScript, InteropError, TypedThrough},
+};
 use bevy_rapier2d::{
     plugin::{NoUserData, RapierPhysicsPlugin},
     prelude::{Collider, CollisionGroups, Group},
     rapier::prelude::RigidBody,
 };
 
-use crate::physics::bindings::{CollisionQueryCachedState, register_global_physics_functions};
+use crate::physics::bindings::{
+    CollisionQueryCachedState, register_global_physics_functions, register_group_functions,
+};
 
 mod bindings;
 
@@ -28,9 +34,9 @@ pub enum CollisionGroup {
     Terrain,
 }
 
-impl Into<Group> for CollisionGroup {
-    fn into(self) -> Group {
-        match self {
+impl From<CollisionGroup> for Group {
+    fn from(val: CollisionGroup) -> Self {
+        match val {
             CollisionGroup::Projectile => Group::GROUP_1,
             CollisionGroup::ControlledEntity => Group::GROUP_2,
             CollisionGroup::Terrain => Group::GROUP_3,
@@ -54,5 +60,6 @@ impl Plugin for PhysicsPlugin {
         }
 
         register_global_physics_functions(app.world_mut());
+        register_group_functions(app.world_mut());
     }
 }

--- a/src/spells/bindings.rs
+++ b/src/spells/bindings.rs
@@ -1,7 +1,7 @@
 use crate::{
     mods::{
-        mod_descriptor_loaded_assets::{self, ModDescriptorLoadedAssets},
         mod_descriptor_asset::ModDescriptorAsset,
+        mod_descriptor_loaded_assets::{self, ModDescriptorLoadedAssets},
     },
     spells::{
         dotgraph::dot_graph_to_spell_graph,
@@ -54,6 +54,7 @@ impl World {
     fn cast_spell(
         ctxt: FunctionCallContext,
         spell: V<Spell>,
+        caster: V<Entity>,
         position: V<Vec2>,
         velocity: V<Vec2>,
     ) -> Result<(), InteropError> {
@@ -63,7 +64,12 @@ impl World {
         world.with_world_mut_access(|w| {
             w.commands()
                 // could do ref but we need to clone anyway
-                .queue(CastSpell::new(spell.into_inner(), *position, *velocity));
+                .queue(CastSpell::new(
+                    *caster,
+                    spell.into_inner(),
+                    *position,
+                    *velocity,
+                ));
 
             // immediately apply command
             w.flush();

--- a/src/spells/executor.rs
+++ b/src/spells/executor.rs
@@ -6,6 +6,7 @@ use bevy::{
         entity::Entity,
         error::trace,
         message::{Message, MessageReader},
+        query::With,
         reflect::ReflectResource,
         resource::Resource,
         system::{Command, Local, Query, Res, ResMut, SystemState},
@@ -34,10 +35,14 @@ use petgraph::{
     visit::{Dfs, EdgeRef, Walker},
 };
 
-use crate::spells::{
-    dotgraph::{SpellGraphNode, SpellGraphTransition},
-    spell::{LiveSpell, WithLifetime},
-    spell_component_asset::SpellComponentAsset,
+use crate::{
+    character::controllable_character::Character,
+    spells::{
+        dotgraph::{SpellGraphNode, SpellGraphTransition},
+        mana::Mana,
+        spell::{LiveSpell, WithLifetime},
+        spell_component_asset::SpellComponentAsset,
+    },
 };
 
 type NodeId = usize;
@@ -261,26 +266,45 @@ impl SpellEventPayload {
         match self {
             SpellEventPayload::Cast { .. } => {}
             SpellEventPayload::HitCharacter { other_entity, .. } => {
-                dest.push(ReflectReference::new_allocated(*other_entity, &mut allocator).into())
+                dest.push(ReflectReference::new_allocated(*other_entity, allocator).into())
             }
             SpellEventPayload::HitTerrain { other_entity, .. } => {
-                dest.push(ReflectReference::new_allocated(*other_entity, &mut allocator).into())
+                dest.push(ReflectReference::new_allocated(*other_entity, allocator).into())
             }
             SpellEventPayload::Expired { .. } => {}
             SpellEventPayload::Custom { .. } => {} // TODO: allow args ?
         }
     }
+
+    fn despawn_spell_component(&self, spell_descriptor_asset: &SpellComponentAsset) -> bool {
+        match self {
+            SpellEventPayload::Expired { .. } => true,
+            SpellEventPayload::HitCharacter { .. } | SpellEventPayload::HitTerrain { .. } => {
+                !spell_descriptor_asset.descriptor.dont_expire_on_hit
+            }
+            _ => false,
+        }
+    }
+
+    fn consumes_mana(&self) -> bool {
+        match self {
+            SpellEventPayload::Cast { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 pub struct CastSpell {
+    pub caster: Entity,
     pub graph: Spell,
     pub position: Vec2,
     pub velocity: Vec2,
 }
 
 impl CastSpell {
-    pub fn new(graph: impl Into<Spell>, position: Vec2, velocity: Vec2) -> Self {
+    pub fn new(caster: Entity, graph: impl Into<Spell>, position: Vec2, velocity: Vec2) -> Self {
         Self {
+            caster,
             graph: graph.into(),
             position,
             velocity,
@@ -294,7 +318,7 @@ impl Command for CastSpell {
             .remove_resource::<AbilityExecutions>()
             .expect("missing resource");
 
-        let execution = AbilityExecution::new(self.graph);
+        let execution = AbilityExecution::new(self.caster, self.graph);
 
         world.write_message(SpellEvent {
             execution_id: execution.id,
@@ -309,6 +333,7 @@ impl Command for CastSpell {
 }
 
 pub struct AbilityExecution {
+    pub caster: Entity,
     pub id: AbilityExecutionId,
     pub unprocessed_events: VecDeque<SpellEvent>,
     pub graph: Spell,
@@ -316,19 +341,22 @@ pub struct AbilityExecution {
     pub next_node: NodeId,
     pub state: AbilityExecutionState,
     pub last_cast_entity: Entity,
+    pub delay_left_miliseconds: f64,
 }
 
 impl AbilityExecution {
-    pub fn new(graph: Spell) -> Self {
+    pub fn new(caster: Entity, graph: Spell) -> Self {
         static ID_HEAD: AtomicUsize = AtomicUsize::new(0);
 
         Self {
+            caster,
             id: ID_HEAD.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             unprocessed_events: Default::default(),
             next_node: 0,
             graph,
             state: AbilityExecutionState::Executing,
             last_cast_entity: Entity::PLACEHOLDER,
+            delay_left_miliseconds: 0.,
         }
     }
 }
@@ -357,12 +385,13 @@ pub fn spell_executions_live(executions: Res<AbilityExecutions>) -> bool {
 struct StepPlan {
     spell_component_to_execute: Handle<SpellComponentAsset>,
     progress_to_next_spell_after_execution: Option<NodeId>,
-    terminate_spell_after_execution: bool,
 }
 
 pub fn progress_spell_executions(
     world: &mut World,
+    mut time_state: Local<SystemState<Res<Time<Virtual>>>>,
     mut query_state: Local<SystemState<Query<(&Transform, &Velocity)>>>,
+    mut query_caster_mana: Local<SystemState<Query<&mut Mana, With<Character>>>>,
 ) {
     let mut executions = world
         .remove_resource::<AbilityExecutions>()
@@ -383,8 +412,19 @@ pub fn progress_spell_executions(
         any_finished = true;
     };
 
+    let elapsed_time_ms = time_state.get(world).delta_secs_f64() * 1000.;
+
     for (_, execution) in &mut executions.0 {
-        while let Some(event) = execution.unprocessed_events.pop_front() {
+        let mut caster_current_mana = query_caster_mana
+            .get_mut(world)
+            .get(execution.caster)
+            .map(|m| m.current)
+            .unwrap_or_default();
+
+        execution.delay_left_miliseconds -= elapsed_time_ms;
+        while execution.delay_left_miliseconds <= 0.
+            && let Some(event) = execution.unprocessed_events.pop_front()
+        {
             let plan = match plan_execution_for_event(execution, &event.payload) {
                 Ok(plan) => plan,
                 Err(err) => {
@@ -410,11 +450,15 @@ pub fn progress_spell_executions(
                     }
                 };
 
-            trace!("Executing spell event: {:?}", event.payload);
-
-            if plan.terminate_spell_after_execution {
-                mark_terminal_state(execution);
+            if event.payload.consumes_mana() {
+                caster_current_mana -= spell_descriptor_asset.descriptor.mana_drain_per_shot;
+                if caster_current_mana < 0. {
+                    mark_terminal_state(execution);
+                    continue;
+                }
             }
+
+            trace!("Executing spell event: {:?}", event.payload);
 
             let (entity_ref, entity) = resolve_or_spawn_cast_entity(
                 world,
@@ -424,6 +468,13 @@ pub fn progress_spell_executions(
                 spell_descriptor_asset,
                 &plan.spell_component_to_execute,
             );
+
+            if event
+                .payload
+                .despawn_spell_component(spell_descriptor_asset)
+            {
+                world.commands().entity(entity).despawn();
+            }
 
             // we have to do this here just before the callback
             // because the callback itself may despawn the entity, meaning we won't have access to the transform
@@ -471,9 +522,17 @@ pub fn progress_spell_executions(
                     },
                 });
                 execution.next_node = move_to_node;
+                execution.delay_left_miliseconds =
+                    spell_descriptor_asset.descriptor.delay_milliseconds;
             }
             execution.last_cast_entity = entity;
         }
+
+        query_caster_mana
+            .get_mut(world)
+            .get_mut(execution.caster)
+            .iter_mut()
+            .for_each(|m| m.current = caster_current_mana);
     }
 
     // cleanup
@@ -487,7 +546,7 @@ pub fn progress_spell_executions(
     world.insert_resource(spell_descriptor_assets);
 }
 
-pub fn plan_execution_for_event(
+fn plan_execution_for_event(
     execution: &AbilityExecution,
     payload: &SpellEventPayload,
 ) -> Result<StepPlan, String> {
@@ -513,7 +572,6 @@ pub fn plan_execution_for_event(
     Ok(StepPlan {
         spell_component_to_execute: spell_to_execute,
         progress_to_next_spell_after_execution,
-        terminate_spell_after_execution: matches!(payload, SpellEventPayload::Expired { .. }),
     })
 }
 
@@ -555,7 +613,14 @@ fn resolve_or_spawn_cast_entity(
                 .get_resource::<Time<Virtual>>()
                 .expect("missing time resource");
             let entity = world
-                .spawn((LiveSpell::new(execution.id, pos, vel, time, handle.clone(), spell)))
+                .spawn(LiveSpell::new(
+                    execution.id,
+                    pos,
+                    vel,
+                    time,
+                    handle.clone(),
+                    spell,
+                ))
                 .id();
 
             let allocated = ReflectReference::new_allocated(entity, &mut allocator);

--- a/src/spells/mana.rs
+++ b/src/spells/mana.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{component::Component, reflect::ReflectComponent},
+    ecs::{component::Component, reflect::ReflectComponent, system::EntityCommand},
     reflect::Reflect,
 };
 

--- a/src/spells/spell_component_asset.rs
+++ b/src/spells/spell_component_asset.rs
@@ -26,7 +26,9 @@ pub struct SpellComponentDescriptor {
     /// The delay after which the next component can be triggered following this one.
     /// If less than the time between frames, will trigger a
     /// component every frame, but no more frequently than that.
-    pub delay_milliseconds: f32,
+    ///
+    /// The delay only applies after the component is cast, before the next one is executed
+    pub delay_milliseconds: f64,
     /// The time after which this component is killed, and its death effect triggered
     pub lifetime_milliseconds: f32,
     /// Components can be slotted with children components, for example
@@ -38,6 +40,10 @@ pub struct SpellComponentDescriptor {
     /// If false will spawn a collider on the spell and send collision events to the spell
     #[serde(default)]
     pub disable_collisions: bool,
+    /// If set will prevent the component from being killed when
+    /// it hits an entity or terrain
+    #[serde(default)]
+    pub dont_expire_on_hit: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default, Reflect)]


### PR DESCRIPTION
Adds mana calculation against the caster of a spell to the execution, as well as allows delaying casts via `delay_miliseconds`

Also makes the executor despawn entities on terminal states like on_hit or on_expire immediately after handling the event